### PR TITLE
differential_odometry: Fix publishing twist coordinate frame

### DIFF
--- a/fmProcessors/platform_processing/differential_odometry/src/differential_odometry_node.cpp
+++ b/fmProcessors/platform_processing/differential_odometry/src/differential_odometry_node.cpp
@@ -360,7 +360,7 @@ public:
 			// publish odometry message
 			odom.header.stamp = time_now;
 			odom.header.frame_id = odom_frame;
-			odom.child_frame_id = odom_frame;
+			odom.child_frame_id = base_frame;
 			odom.pose.pose.position.x = x;
 			odom.pose.pose.position.y = y;
 			odom.pose.pose.orientation = odom_quat;

--- a/fmProcessors/platform_processing/differential_odometry/src/differential_odometry_node.cpp
+++ b/fmProcessors/platform_processing/differential_odometry/src/differential_odometry_node.cpp
@@ -360,6 +360,7 @@ public:
 			// publish odometry message
 			odom.header.stamp = time_now;
 			odom.header.frame_id = odom_frame;
+			odom.child_frame_id = odom_frame;
 			odom.pose.pose.position.x = x;
 			odom.pose.pose.position.y = y;
 			odom.pose.pose.orientation = odom_quat;


### PR DESCRIPTION
According to http://docs.ros.org/api/nav_msgs/html/msg/Odometry.html, the twist
in the odometry message should be specified in the frame given by the
child_frame_id.